### PR TITLE
Fixed missing quotes to just copy & paste to terminal

### DIFF
--- a/faq/index.md
+++ b/faq/index.md
@@ -55,7 +55,7 @@ We highly recommend the use of a lock file in your cron script, so that you do n
 
 Create your unique lockfile with:
 
-    cat /dev/urandom | tr -dc [:alnum:] | head -c12; echo
+    cat /dev/urandom | tr -dc '[:alnum:]' | head -c12; echo
 
 #### After I setup a mirror, what next? ####
 


### PR DESCRIPTION
I just setup a repoforge mirror and I noticed that if you copy and paste the line for generating a random name for the lockfile, bash complains because quotes are missing for the regex.
I fixed that by just adding quotes.
