### PR TITLE
Remove obsolete instructions about disabling repository

### DIFF
--- a/use/index.md
+++ b/use/index.md
@@ -24,4 +24,3 @@ Hints:
 * Use `rpm -ivh package-filename` to install the rpmforge-release package (also works with URLs)
 * You can use `wget` or `curl` to download the package using one of the above links if needed (for example on a server with no X Window)
 * Then you can use `yum` to install the available packages from the RepoForge repo, e.g. `yum install --enablerepo=rpmforge-extras``
-* Afterward, you can disable accidental updates from the repo by setting `enabled = 0` in the repo definition file in `/etc/yum.repos.d/`


### PR DESCRIPTION
The rpmforge-extras repository is already disabled by default, according to https://wiki.centos.org/AdditionalResources/Repositories/RPMForge. No need to disable it manually (unless I misunderstood these instructions).

Out of the box, `/etc/yum.repos.d/rpmforge.repo` looks like this for me:

```
[rpmforge]
name = RHEL $releasever - RPMforge.net - dag
baseurl = http://apt.sw.be/redhat/el6/en/$basearch/rpmforge
mirrorlist = http://mirrorlist.repoforge.org/el6/mirrors-rpmforge
#mirrorlist = file:///etc/yum.repos.d/mirrors-rpmforge
enabled = 1
protect = 0
gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmforge-dag
gpgcheck = 1

[rpmforge-extras]
name = RHEL $releasever - RPMforge.net - extras
baseurl = http://apt.sw.be/redhat/el6/en/$basearch/extras
mirrorlist = http://mirrorlist.repoforge.org/el6/mirrors-rpmforge-extras
#mirrorlist = file:///etc/yum.repos.d/mirrors-rpmforge-extras
enabled = 0
protect = 0
gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmforge-dag
gpgcheck = 1

[rpmforge-testing]
name = RHEL $releasever - RPMforge.net - testing
baseurl = http://apt.sw.be/redhat/el6/en/$basearch/testing
mirrorlist = http://mirrorlist.repoforge.org/el6/mirrors-rpmforge-testing
#mirrorlist = file:///etc/yum.repos.d/mirrors-rpmforge-testing
enabled = 0
protect = 0
gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmforge-dag
gpgcheck = 1

```

(notice how enabled = 0 is already set for the two relevant repos).
